### PR TITLE
fix: use `tx.origin == self` to determine EOA origination

### DIFF
--- a/contracts/Purse.vy
+++ b/contracts/Purse.vy
@@ -35,7 +35,7 @@ def add_accessory(accessory: IAccessory):
     @param accessory The address of the new accessory that implements IAccessory
     """
     # NOTE: Can only work in a EIP-7702 context
-    assert msg.sender == self, "Purse:!authorized"
+    assert tx.origin == self, "Purse:!authorized"
 
     methods: DynArray[bytes4, 100] = staticcall accessory.getMethodIds()
     for method: bytes4 in methods:
@@ -56,7 +56,7 @@ def remove_accessory(accessory: IAccessory):
     @param accessory The address of the old accessory that implements IAccessory
     """
     # NOTE: Can only work in a EIP-7702 context
-    assert msg.sender == self, "Purse:!authorized"
+    assert tx.origin == self, "Purse:!authorized"
 
     methods: DynArray[bytes4, 100] = staticcall accessory.getMethodIds()
     for method: bytes4 in methods:

--- a/contracts/Purse.vy
+++ b/contracts/Purse.vy
@@ -35,7 +35,7 @@ def add_accessory(accessory: IAccessory):
     @param accessory The address of the new accessory that implements IAccessory
     """
     # NOTE: Can only work in a EIP-7702 context
-    assert tx.origin == self, "Purse:!authorized"
+    assert tx.origin == self and tx.origin == msg.sender, "Purse:!authorized"
 
     methods: DynArray[bytes4, 100] = staticcall accessory.getMethodIds()
     for method: bytes4 in methods:
@@ -56,7 +56,7 @@ def remove_accessory(accessory: IAccessory):
     @param accessory The address of the old accessory that implements IAccessory
     """
     # NOTE: Can only work in a EIP-7702 context
-    assert tx.origin == self, "Purse:!authorized"
+    assert tx.origin == self and tx.origin == msg.sender, "Purse:!authorized"
 
     methods: DynArray[bytes4, 100] = staticcall accessory.getMethodIds()
     for method: bytes4 in methods:

--- a/contracts/accessories/Multicall.vy
+++ b/contracts/accessories/Multicall.vy
@@ -17,7 +17,7 @@ struct Call:
 @external
 def execute(calls: DynArray[Call, 100]):
     # NOTE: Can only work in a EIP-7702 context from Purse
-    assert msg.sender == self, "Multicall:!authorized"
+    assert tx.origin == self, "Multicall:!authorized"
 
     for call: Call in calls:
         raw_call(call.target, call.data, value=call.value)


### PR DESCRIPTION
Much safer implementation of authorization check for execution by EOA