### PR TITLE
refactor(Contracts): remove IAccessory interface; use explicit methods

### DIFF
--- a/contracts/IAccessory.vyi
+++ b/contracts/IAccessory.vyi
@@ -1,3 +1,0 @@
-@pure
-@external
-def getMethodIds() -> DynArray[bytes4, 100]: ...

--- a/contracts/accessories/Multicall.vy
+++ b/contracts/accessories/Multicall.vy
@@ -1,13 +1,3 @@
-from .. import IAccessory
-implements: IAccessory
-
-
-@pure
-@external
-def getMethodIds() -> DynArray[bytes4, 100]:
-    return [0x3f707e6b]
-
-
 struct Call:
     target: address
     value: uint256


### PR DESCRIPTION
Realized we can just allow arbitrarily enabling and disabling method IDs from any contract, it doesn't have to implement an arbitrary interface