### PR TITLE
feat(Accessory): Create2 Deployer

### DIFF
--- a/contracts/accessories/Create.vy
+++ b/contracts/accessories/Create.vy
@@ -1,0 +1,72 @@
+# pragma version 0.4.2
+
+# NOTE: Maximum possible `raw_create` initcode size
+MAX_CODE_SIZE: constant(uint16) = 41592
+
+event Deployment:
+    deployment: indexed(address)
+    salt: indexed(bytes32)
+    initcode: Bytes[MAX_CODE_SIZE]
+
+event DeploymentFromBlueprint:
+    deployment: indexed(address)
+    blueprint: indexed(address)
+    salt: indexed(bytes32)
+    args: Bytes[MAX_CODE_SIZE]
+
+
+@external
+def create(
+    initcode_or_args: Bytes[MAX_CODE_SIZE] = b"",
+    blueprint: address = empty(address),
+    salt: bytes32 = empty(bytes32),
+    forwarded_value: uint256 = 0,
+) -> address:
+    deployment: address = empty(address)
+
+    if blueprint != empty(address):
+        if salt != empty(bytes32):
+            deployment = create_from_blueprint(
+                blueprint,
+                initcode_or_args,
+                raw_args=True,
+                value=forwarded_value,
+                salt=salt,
+            )
+
+        else:
+            deployment = create_from_blueprint(
+                blueprint,
+                initcode_or_args,
+                raw_args=True,
+                value=forwarded_value,
+            )
+
+        log DeploymentFromBlueprint(
+            deployment=deployment,
+            blueprint=blueprint,
+            salt=salt,
+            args=initcode_or_args,
+        )
+
+    else:
+        if salt != empty(bytes32):
+            deployment = raw_create(
+                initcode_or_args,
+                value=forwarded_value,
+                salt=salt,
+            )
+        else:
+            deployment = raw_create(
+                initcode_or_args,
+                value=forwarded_value,
+            )
+
+        log Deployment(
+            deployment=deployment,
+            salt=salt,
+            initcode=initcode_or_args,
+        )
+
+    assert deployment != empty(address), "Create:!deployment"
+    return deployment

--- a/contracts/accessories/README.md
+++ b/contracts/accessories/README.md
@@ -1,5 +1,16 @@
 # Purse 1st Party Accessories
 
+## Create
+
+_(see [`Create.vy`](./Create.vy))_
+
+This accessory that allows a Purse to create new contracts thru blueprints using 4 variations of `create(*args)`.
+Once deployed, this contract also emits an event to keep track of contracts you've deployed.
+
+```{notice}
+Right now, this module only supports blueprints, although `raw_create` is coming in Vyper 0.4.2.
+```
+
 ## Multicall
 
 _(see [`Multicall.vy`](./Multicall.vy))_

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,11 @@ def multicall(project, owner):
 
 
 @pytest.fixture(scope="session")
+def create2_deployer(project, owner):
+    return owner.deploy(project.Create)
+
+
+@pytest.fixture(scope="session")
 def sponsor(project, owner):
     return owner.deploy(project.Sponsor)
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,0 +1,61 @@
+import pytest
+from ape.utils import ZERO_ADDRESS
+
+
+@pytest.fixture()
+def purse(singleton, owner, create2_deployer, encode_accessory_data):
+    with owner.delegate_to(
+        singleton,
+        # NOTE: Add multicall as an accessory at the same time
+        data=singleton.update_accessories.encode_input(
+            encode_accessory_data(
+                # Accessory
+                create2_deployer,
+                # Methods
+                create2_deployer.create,
+            )
+        ),
+    ) as purse:
+        # NOTE: So we can decode logs
+        purse.contract_type.abi.extend(create2_deployer.contract_type.abi)
+        yield purse
+
+
+@pytest.fixture(scope="module")
+def container(project):
+    return project.Multicall  # NOTE: Just random choice
+
+
+@pytest.fixture(scope="module")
+def blueprint(container, owner):
+    return owner.declare(container).contract_address
+
+
+@pytest.mark.parametrize("salt", [b"", b"Custom Salt"])
+def test_create_blueprint(purse, create2_deployer, blueprint, salt):
+    if len(salt) < 32:
+        salt = salt + b"\x00" * (32 - len(salt))
+
+    tx = purse(
+        data=create2_deployer.create.encode_input(b"", blueprint, salt),
+        sender=purse,
+    )
+    assert tx.events == [
+        purse.DeploymentFromBlueprint(blueprint=blueprint, salt=salt, args=b""),
+    ]
+
+
+@pytest.mark.parametrize("salt", [b"", b"Custom Salt"])
+def test_raw_create(purse, create2_deployer, container, salt):
+    if len(salt) < 32:
+        salt = salt + b"\x00" * (32 - len(salt))
+
+    initcode = container.contract_type.get_deployment_bytecode()
+
+    tx = purse(
+        data=create2_deployer.create.encode_input(initcode, ZERO_ADDRESS, salt),
+        sender=purse,
+    )
+    assert tx.events == [
+        purse.Deployment(salt=salt, initcode=initcode),
+    ]


### PR DESCRIPTION
~~requires: #7~~

This accessory allows deploying contracts either via ERC-5202 Blueprints or directly via initcode, with or without CREATE2 salt