### PR TITLE
fix(Purse): use `@raw_return` to skip decoding `raw_call` response

### DIFF
--- a/contracts/Purse.vy
+++ b/contracts/Purse.vy
@@ -49,6 +49,7 @@ def update_accessories(updates: DynArray[AccessoryUpdate, 100]):
 @payable
 @external
 @reentrant
+@raw_return
 def __default__() -> Bytes[65535]:
     # NOTE: Don't bork value transfers in
     if msg.value > 0 or len(msg.data) < 4:


### PR DESCRIPTION
fixes: #10
requires: https://github.com/vyperlang/vyper/pull/4568